### PR TITLE
Golint fix and UseModernBuildSystem=0 build option for the test

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,6 +32,7 @@ workflows:
     - path::./:
         title: Step Test
         inputs:
+        - options: --buildFlag="-UseModernBuildSystem=0"
         - target: emulator
     - script:
         title: Output test

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 2
+format_version: 6
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
@@ -8,9 +8,11 @@ app:
 
 workflows:
   test:
-    before_run:
-    - go-tests
     steps:
+    - go-list:
+    - golint:
+    - errcheck:
+    - go-test:
     - script:
         inputs:
         - content: |-
@@ -52,60 +54,6 @@ workflows:
                 echo "Does not exist: apk file's path"
                 exit 1
             fi
-
-  go-tests:
-    before_run:
-    - _install-test-tools
-    steps:
-    - script:
-        title: Export go files to test
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            no_vendor_paths="$(go list ./... | grep -v vendor)"
-            envman add --key GOLIST_WITHOUT_VENDOR --value "$no_vendor_paths"
-    - script:
-        title: Err check
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            errcheck -asserts=true -blank=true $GOLIST_WITHOUT_VENDOR
-    - script:
-        title: Go lint
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            while read -r line; do
-              echo "-> Linting: $line"
-              golint_out="$(golint $line)"
-              if [[ "${golint_out}" != "" ]] ; then
-                echo "=> Golint issues found:"
-                echo "${golint_out}"
-                exit 1
-              fi
-            done <<< "$GOLIST_WITHOUT_VENDOR"
-    - script:
-        title: Go test
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            go test ./...
-  _install-test-tools:
-    steps:
-    - script:
-        title: Install required testing tools
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            # Check for unhandled errors
-            go get -u -v github.com/kisielk/errcheck
-            # Go lint
-            go get -u -v github.com/golang/lint/golint
 
   # ----------------------------------------------------------------
   # --- Utility workflows


### PR DESCRIPTION
- fix: update the go-test workflows

---

- fix: add `--buildFlag="-UseModernBuildSystem=0"` build config for the test workflow because of the Xcode 10 stacks.
```
The new build system will fail to create the iOS archive for older projects:
error: archive not found at path ‘/Users/vagrant/git/platforms/ios/[REDACTED].xcarchive’
** EXPORT FAILED **
```