### PR TITLE
Don't reset platform version from that specified in the project

### DIFF
--- a/cordova/cordova.go
+++ b/cordova/cordova.go
@@ -70,6 +70,10 @@ func (builder *Model) commandSlice(cmd ...string) []string {
 		cmdSlice = append(cmdSlice, builder.customOptions...)
 	}
 
+	if len(cmd) == 1 && cmd[0] == "platform" {
+		cmdSlice = append(cmdSlice, "--nosave")
+	}
+	
 	return cmdSlice
 }
 


### PR DESCRIPTION
Respect the config value of platform version to use.

The Cordova Archive step runs the commands
`cordova "platform" "rm" "<platform>"` and 
`cordova "platform" "add" "<platform>"`
which deletes the line from config.xml that contains a specifier for the versions of any platforms your project uses. When this `cordova platform rm` runs if you have a specific version specified that information gets lost, then when the platform is re-added cordova will use the latest version by default.  the `--nosave` option prevents the cordova cli from modifying the `config.xml` so the specified version will still be maintained over rm and add operations.